### PR TITLE
remove undeclared struct warning

### DIFF
--- a/app/include/zmk/split/bluetooth/central.h
+++ b/app/include/zmk/split/bluetooth/central.h
@@ -3,6 +3,8 @@
 
 #include <bluetooth/addr.h>
 #include <zmk/behavior.h>
+#include <zmk/rgb_underglow.h>
+#include <zmk/backlight.h>
 
 int zmk_split_bt_invoke_behavior(uint8_t source, struct zmk_behavior_binding *binding,
                                  struct zmk_behavior_binding_event event, bool state);


### PR DESCRIPTION
Hello,

Wouldn't it be best practice to declare the structs used in a header? That would remove the compile warnings:
```
[48/344] Building C object CMakeFiles/app.dir/src/keymap.c.obj
In file included from /app/zmk/app/src/keymap.c:20:
/app/zmk/app/include/zmk/split/bluetooth/central.h:10:36: warning: 'struct zmk_periph_led' declared inside parameter list will not be visible outside of this definition or declaration
   10 | int zmk_split_bt_update_led(struct zmk_periph_led *periph);
      |                                    ^~~~~~~~~~~~~~
/app/zmk/app/include/zmk/split/bluetooth/central.h:11:35: warning: 'struct backlight_state' declared inside parameter list will not be visible outside of this definition or declaration
   11 | int zmk_split_bt_update_bl(struct backlight_state *periph);
      |                                   ^~~~~~~~~~~~~~~
[62/344] Building C object CMakeFiles/app.dir/src/backlight.c.obj
In file included from /app/zmk/app/src/backlight.c:26:
/app/zmk/app/include/zmk/split/bluetooth/central.h:10:36: warning: 'struct zmk_periph_led' declared inside parameter list will not be visible outside of this definition or declaration
   10 | int zmk_split_bt_update_led(struct zmk_periph_led *periph);
      |                                    ^~~~~~~~~~~~~~
[67/344] Building C object CMakeFiles/app.dir/src/rgb_underglow.c.obj
In file included from /app/zmk/app/src/rgb_underglow.c:35:
/app/zmk/app/include/zmk/split/bluetooth/central.h:11:35: warning: 'struct backlight_state' declared inside parameter list will not be visible outside of this definition or declaration
   11 | int zmk_split_bt_update_bl(struct backlight_state *periph);
      |                                   ^~~~~~~~~~~~~~~
```