### PR TITLE
Clarify bound/configuration of number of Bluetooth profile colors

### DIFF
--- a/app/src/rgb_underglow.c
+++ b/app/src/rgb_underglow.c
@@ -227,8 +227,10 @@ static void zmk_rgb_underglow_central_send() {
     }
 }
 
-static const struct led_rgb BT_COLORS[8] = {LED_RGB(0xFFFFFF), LED_RGB(0x0000FF), LED_RGB(0xFF0000),
-                                            LED_RGB(0x00FF00), LED_RGB(0x000000)};
+#define NUM_BT_COLORS 4
+
+static const struct led_rgb BT_COLORS[NUM_BT_COLORS] = {LED_RGB(0xFFFFFF), LED_RGB(0x0000FF),
+                                                        LED_RGB(0xFF0000), LED_RGB(0x00FF00)};
 #endif
 
 static const struct led_rgb LAYER_COLORS[8] = {
@@ -290,12 +292,13 @@ static void zmk_rgb_underglow_effect_kinesis() {
 
     // set second led to bluetooth state, blinking quickly if bluetooth not paired,
     // and slowly if not connected
+    int bt_idx = zmk_ble_active_profile_index();
     if (zmk_ble_active_profile_is_open()) {
         bt_blinking = zmk_kinesis_blink_step(0, 2);
     } else if (!zmk_ble_active_profile_is_connected()) {
         bt_blinking = zmk_kinesis_blink_step(1, 13);
     }
-    pixels[1] = bt_blinking ? LED_RGB(0x000000) : BT_COLORS[zmk_ble_active_profile_index()];
+    pixels[1] = (bt_idx < NUM_BT_COLORS && !bt_blinking) ? BT_COLORS[bt_idx] : LED_RGB(0x000000);
 
     // set third led to layer state
     pixels[2] = LAYER_COLORS[layer_color_left];


### PR DESCRIPTION
The list of Bluetooth profile colors is unnecessarily confusing because it uses the fact that C zero initializes any final unspecified array members. Clarify things with a constant.