### PR TITLE
fix(keymap): restore no_init param dropped in refil #3047 cherry-pick

### DIFF
--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -72,15 +72,16 @@ static uint8_t keymap_layer_orders[ZMK_KEYMAP_LAYERS_LEN];
 
 #endif // IS_ENABLED(CONFIG_ZMK_KEYMAP_LAYER_REORDERING)
 
-#define KEYMAP_VAR(_name, _opts)                                                                   \
+#define KEYMAP_VAR(_name, _opts, no_init)                                                                   \
     static _opts struct zmk_behavior_binding _name[ZMK_KEYMAP_LAYERS_LEN][ZMK_KEYMAP_LEN] = {      \
         COND_CODE_0(no_init, (ZMK_KEYMAP_LAYERS_FOREACH_SEP(TRANSFORMED_LAYER, (, ))), (0))};
 
-KEYMAP_VAR(zmk_keymap, COND_CODE_1(IS_ENABLED(CONFIG_ZMK_KEYMAP_SETTINGS_STORAGE), (), (const)))
+KEYMAP_VAR(zmk_keymap, COND_CODE_1(IS_ENABLED(CONFIG_ZMK_KEYMAP_SETTINGS_STORAGE), (), (const)),
+           IS_ENABLED(CONFIG_ZMK_STUDIO))
 
 #if IS_ENABLED(CONFIG_ZMK_KEYMAP_SETTINGS_STORAGE)
 
-KEYMAP_VAR(zmk_stock_keymap, const)
+KEYMAP_VAR(zmk_stock_keymap, const, 0)
 
 static char zmk_keymap_layer_names[ZMK_KEYMAP_LAYERS_LEN][CONFIG_ZMK_KEYMAP_LAYER_NAME_MAX_LEN] = {
     ZMK_KEYMAP_LAYERS_FOREACH_SEP(LAYER_NAME, (, ))};

--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -954,6 +954,9 @@ int keymap_init(void) {
 #if IS_ENABLED(CONFIG_ZMK_KEYMAP_LAYER_REORDERING)
     load_stock_keymap_layer_ordering();
 #endif
+#if IS_ENABLED(CONFIG_ZMK_STUDIO)
+    reload_from_stock_keymap();
+#endif
 
     return 0;
 }


### PR DESCRIPTION
Human TLDR: I had an issue with my advantage360-pro-zmk artifacts that caused every key to be nullopt upon flash. The fix traced primarily to this branch, as found by claude, and I confirmed it worked afterwards.

## Summary (By claude)

Commit `7bb4bd5f` ("fix(core): Generate correct keymap layer names for all builds (#3047)") on the `adv360-z3.5-2` branch is an **incomplete port** of upstream ZMK #3047. It drops **two** matched pieces of the keymap-initialization change, which together leave the keymap empty at runtime. Both compile cleanly — CI stays green and produces a valid `.uf2` — so nothing flags the problem, but the flashed firmware has no working keys.

This PR restores both dropped pieces to match `zmkfirmware/zmk`.

## Bug 1 — `no_init` parameter dropped from `KEYMAP_VAR`

The macro body references `no_init`, but the parameter was dropped from the signature (`KEYMAP_VAR(_name, _opts)`) and both call sites, leaving `no_init` as an **undefined identifier**. `COND_CODE_0(no_init, (…layers…), (0))` therefore silently expands to the else branch `(0)`, zero-initializing the keymap binding array:

```c
static … struct zmk_behavior_binding zmk_keymap[…][…] = { 0 };
```

Effect: **every build** (Studio and non-Studio) ships a zeroed compile-time keymap.

## Bug 2 — `reload_from_stock_keymap()` dropped from `keymap_init()`

For Studio builds (`CONFIG_ZMK_STUDIO=y`), `zmk_keymap` is intentionally left uninitialized at compile time (`no_init`) and must be populated at boot from `zmk_stock_keymap`. Upstream does this in `keymap_init()`; this branch's version omits it:

```c
int keymap_init(void) {
#if IS_ENABLED(CONFIG_ZMK_KEYMAP_LAYER_REORDERING)
    load_stock_keymap_layer_ordering();
#endif
    return 0;              // <-- never calls reload_from_stock_keymap()
}
```

Effect: even after Bug 1 is fixed, **Studio builds boot with an all-zero keymap** — and a settings reset does not help, because nothing ever copies the stock keymap into the live one. Non-Studio builds are unaffected (their keymap is initialized from devicetree at compile time).

## Fix

```diff
-#define KEYMAP_VAR(_name, _opts)                                                    \
+#define KEYMAP_VAR(_name, _opts, no_init)                                           \
     static _opts struct zmk_behavior_binding _name[ZMK_KEYMAP_LAYERS_LEN][ZMK_KEYMAP_LEN] = { \
         COND_CODE_0(no_init, (ZMK_KEYMAP_LAYERS_FOREACH_SEP(TRANSFORMED_LAYER, (, ))), (0))};

-KEYMAP_VAR(zmk_keymap, COND_CODE_1(IS_ENABLED(CONFIG_ZMK_KEYMAP_SETTINGS_STORAGE), (), (const)))
+KEYMAP_VAR(zmk_keymap, COND_CODE_1(IS_ENABLED(CONFIG_ZMK_KEYMAP_SETTINGS_STORAGE), (), (const)),
+           IS_ENABLED(CONFIG_ZMK_STUDIO))

-KEYMAP_VAR(zmk_stock_keymap, const)
+KEYMAP_VAR(zmk_stock_keymap, const, 0)
```

```diff
 int keymap_init(void) {
 #if IS_ENABLED(CONFIG_ZMK_KEYMAP_LAYER_REORDERING)
     load_stock_keymap_layer_ordering();
 #endif
+#if IS_ENABLED(CONFIG_ZMK_STUDIO)
+    reload_from_stock_keymap();
+#endif

     return 0;
 }
```

Both hunks match the current `zmkfirmware/zmk` `app/src/keymap.c`.

## Testing

- Confirmed both the corrected `KEYMAP_VAR` macro and `keymap_init()` match the current `zmkfirmware/zmk` version.
- Adv360 **non-Studio** (no-clique) build: keymap populated, keys function.
- Adv360 **Studio** (clique) build: with both fixes, `zmk_keymap` is repopulated from the stock keymap at boot; keys function.
